### PR TITLE
fix typo

### DIFF
--- a/args.go
+++ b/args.go
@@ -14,7 +14,7 @@ const stdin argMode = 0
 // Returns the ROLL(s). It detects if the ROLL(s) were provided as an arg or if they were passed through stdin
 func getRolls() []roll {
 	if argMode(flag.NArg()) == stdin {
-		return rollFromStdin()
+		return rollsFromStdin()
 	}
 	return rollsFromArg()
 }


### PR DESCRIPTION
renamed `rollFromStdin` to `rollsFromStdin` but forgot to change the function call in `args.go`