### PR TITLE
Only one github workflow runs at a time

### DIFF
--- a/.github/workflows/go_test.yaml
+++ b/.github/workflows/go_test.yaml
@@ -1,15 +1,18 @@
 # Copyright skoved
 # SPDX-License-Identifier: MIT
 ---
-name: go_test
+name: Testing
 run-name: Unit Tests (go)
 on:
   push:
     branches:
-      - "main"
+      - main
   pull_request:
     branches:
-      - "main"
+      - main
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -4,9 +4,15 @@
 name: Linting
 run-name: Linting
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,13 @@
 # Copyright skoved
 # SPDX-License-Identifier: MIT
 ---
-name: release
+name: Release
 on:
   push:
     tags:
       - "v*"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
The CI workflows will cancel the previous run only if it was triggered by a pull request. Pushes to a branch will cause the next run to queue.

resolves #20 